### PR TITLE
Save best `global_model` and implement `global_evaluation` callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+dataset/

--- a/README.md
+++ b/README.md
@@ -4,11 +4,40 @@ This repository is maintained to develop and test the Flower framework for 3D me
 
 This code is inspired by the official [Flower FedBN tutorial](https://flower.dev/docs/fedbn-example-pytorch-from-centralized-to-federated.html) 
 
-Before you start using the scripts, please ensure that you have the Pancreas and Spleen data accessible locally and in the right format as detailed in our framework [SegViz](https://github.com/UM2ii/SegViz)
+## Environment Setup
+
+```bash
+# Create a conda environment
+conda create -n um2ii-flower python=3.10 -y
+
+# Activate the environment
+conda activate um2ii-flower
+
+# Install requirements
+pip install -r requirements.txt
+```
+
+Before you start using the scripts, please ensure that you have the Pancreas and Spleen data accessible locally and in the right format as detailed in our framework [SegViz](https://github.com/UM2ii/SegViz). The direct commands to download and extract the dataset are:
+
+```bash
+# let's create first a dataset directory
+mkdir dataset
+cd dataset
+
+# Download Spleen dataset (~1.5GB)
+wget https://msd-for-monai.s3-us-west-2.amazonaws.com/Task09_Spleen.tar
+# now extract it
+tar -xvf Task09_Spleen.tar
+
+# Download Pancreas dataset (~11.5 GB)
+wget https://msd-for-monai.s3-us-west-2.amazonaws.com/Task07_Pancreas.tar
+# now extract it
+tar -xvf Task07_Pancreas.tar
+```
 
 The Pancreas dataset has normal and tumor labels, so please use the script below to convert the dataset into single-label (organ) only. 
 
-```
+```python
 import nibabel as nib
 data_dir_pan = 'path_to_dir_containing_images'
 for image_path in sorted(glob.glob(os.path.join(data_dir_pan, "labelsTr", "*.nii.gz"))):
@@ -18,25 +47,29 @@ for image_path in sorted(glob.glob(os.path.join(data_dir_pan, "labelsTr", "*.nii
     image_file_final = nib.Nifti1Image(image_file_array, image_file.affine)
 ```
 
+## Run the experiment (Centralized)
+
+```bash
+python3 msd.py --spleen-path <path/to/spleen/dataset> --pancreas-path <path/to/spleen/dataset>
+```
+
+## Run the experiment (Federated)
+
 You will need to run the following scripts in separate terminal windows.
 
-```
-# Start the Flower central server using 
-python3 msd.py
-```
-
-```
+```bash
 # Start the Flower server using 
 python3 server.py
 ```
 
-```
+```bash
 # Start the Flower Liver client using 
-python3 client_spleen.py
+python3 client_spleen.py  --spleen-path <path/to/spleen/dataset> 
 ```
-```
+
+```bash
 # Start the Flower Pancreas client using 
-python3 client_pan.py
+python3 client_pan.py --pancreas-path <path/to/spleen/dataset>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flower for 3D medical image segmentation 
 
-This repository is maintained to develop and test the Flower framework for 3D medical image segmentation using the data from the Medical Segmentation Decathalon challenge.
+This repository is maintained to develop and test the [Flower framework](https://flower.ai/) for 3D medical image segmentation using the data from the Medical Segmentation Decathalon challenge.
 
 This code is inspired by the official [Flower FedBN tutorial](https://flower.dev/docs/fedbn-example-pytorch-from-centralized-to-federated.html) 
 
@@ -11,7 +11,7 @@ This code is inspired by the official [Flower FedBN tutorial](https://flower.dev
 conda create -n um2ii-flower python=3.10 -y
 
 # Activate the environment
-conda activate um2ii-flower
+conda activate um2ii-flower # or source activate um2ii-flower
 
 # Install requirements
 pip install -r requirements.txt
@@ -64,12 +64,12 @@ python3 server.py
 
 ```bash
 # Start the Flower Liver client using 
-python3 client_spleen.py  --spleen-path <path/to/spleen/dataset> 
+python3 client_spleen.py  --spleen-path=dataset/Task09_Spleen # or update the path if you didn't follow steps above
 ```
 
 ```bash
 # Start the Flower Pancreas client using 
-python3 client_pan.py --pancreas-path <path/to/spleen/dataset>
+python3 client_pan.py --pancreas-path=dataset/Task07_Pancreas # or update the path if you didn't follow steps above
 ```
 
 

--- a/client_pan.py
+++ b/client_pan.py
@@ -1,3 +1,4 @@
+import argparse
 from monai.utils import first, set_determinism
 from monai.transforms import (
     AsDiscrete,
@@ -53,6 +54,15 @@ USE_FEDBN: bool = True
 
 # pylint: disable=no-member
 DEVICE: str = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+parser = argparse.ArgumentParser(description="Flower Pancrease Client for Medical Segmentation Decathlon")
+parser.add_argument(
+    "--pancreas-path",
+    required=True,
+    type=str,
+    help="Path to the Pancreas dataset (e.g. datasets/Task07_Pancreas). Download from medicaldecathlon.com.",
+)
+
 # pylint: enable=no-member
 config = {
     # data
@@ -142,7 +152,8 @@ class MSDClient(fl.client.NumPyClient):
 def main() -> None:
     """Load data, start MSDClient."""
 
-    data_dir_pan = '/mnt/hdd1/Task07_Pancreas' # Local path to data. Should contain imagesTr and labelsTr subdirs
+    args = parser.parse_args()
+    data_dir_pan = args.pancreas_path # Local path to data. Should contain imagesTr and labelsTr subdirs
     # Load data
     trainloader, testloader, num_examples = msd.load_data(data_dir_pan, -87, 199)
 

--- a/client_spleen.py
+++ b/client_spleen.py
@@ -1,3 +1,4 @@
+import argparse
 from monai.utils import first, set_determinism
 from monai.transforms import (
     AsDiscrete,
@@ -55,6 +56,15 @@ USE_FEDBN: bool = True
 
 # pylint: disable=no-member
 DEVICE: str = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+parser = argparse.ArgumentParser(description="Flower Spleen Client for Medical Segmentation Decathlon")
+parser.add_argument(
+    "--spleen-path",
+    required=True,
+    type=str,
+    help="Path to the Spleen dataset (e.g. datasets/Task09_Spleen). Download from medicaldecathlon.com.",
+)
+
 # pylint: enable=no-member
 config = {
     # data
@@ -146,7 +156,8 @@ class MSDClient(fl.client.NumPyClient):
 def main() -> None:
     """Load data, start MSDClient."""
 
-    data_dir_spleen = '/mnt/hdd1/Task09_Spleen' # Local path to data. Should contain imagesTr and labelsTr subdirs
+    args = parser.parse_args()
+    data_dir_spleen = args.spleen_path  # Local path to data. Should contain imagesTr and labelsTr subdirs
     # Load data
     trainloader, testloader, num_examples = msd.load_data(data_dir_spleen, -57, 164)
 

--- a/msd.py
+++ b/msd.py
@@ -1,6 +1,8 @@
 """Flower code for FedBN on MSD
 """
 
+import argparse
+
 from monai.utils import first, set_determinism
 from monai.transforms import (
     AsDiscrete,
@@ -41,6 +43,21 @@ import numpy as np
 # import wandb
 import copy
 import nibabel as nib
+
+
+parser = argparse.ArgumentParser(description="Flower Server for Medical Segmentation Decathlon")
+parser.add_argument(
+    "--spleen-path",
+    required=True,
+    type=str,
+    help="Path to the Spleen dataset (e.g. datasets/Task09_Spleendown). Download from medicaldecathlon.com.",
+)
+parser.add_argument(
+    "--pancreas-path",
+    required=True,
+    type=str,
+    help="Path to the Pancreas dataset (e.g. datasets/Task07_Pancreas). Download from medicaldecathlon.com.",
+)
 
 config = {
     # data
@@ -108,6 +125,7 @@ def load_data(data_dir, a_min, a_max):
             image_key="image",
             image_threshold=0,
         ),
+    ]
     )
     val_transform = Compose(
         [
@@ -236,14 +254,15 @@ def validate( model: UNet(**config['model_params']),
         return metric
     
 def main():
+    args = parser.parse_args()
+
     DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     
     print("Centralized PyTorch training")
     print("Load data")
     
-    trainloader_spleen, testloader_spleen, _ = load_data('/mnt/hdd1/Task09_Spleen') # Change path to spleen data
-    trainloader_pan, testloader_pan, _ = load_data('/mnt/hdd1/Task07_Pancreas')    # Change path to pancreas data
-    
+    trainloader_spleen, testloader_spleen, _ = load_data(args.spleen_path, -57, 164) # TODO: a_min/max copied from client_spleen
+    trainloader_pan, testloader_pan, _ = load_data(args.pancreas_path, -87, 199) # TODO: a_min/max copied from client_pancreas
     net_spleen = UNet(**config['model_params']).to(DEVICE)
     net_spleen.eval()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+flwr==1.7.0
+monai==1.3.0
+matplotlib==3.8.3
+nibabel==5.2.1
+wandb==0.16.3
+tqdm==4.66.2

--- a/server.py
+++ b/server.py
@@ -92,6 +92,7 @@ def get_evaluate_fn(server_dataset):
 
         log(INFO,"Evaluating global model on a dataset held by the server")
         log(INFO," --------------------------- WARNING ----------------------")
+        log(INFO, "\t\t Global Model evaluation is not implemented")
         sleep(10)
         log(INFO," --------------------------- MUST IMPLEMENT ---------------")
 

--- a/server.py
+++ b/server.py
@@ -1,39 +1,84 @@
 """Flower server example."""
-import flwr as fl
+
+import pickle
+from pathlib import Path
 from collections import OrderedDict
+
+import flwr as fl
+from flwr.server.client_manager import ClientManager
 from flwr.server.client_proxy import ClientProxy
-from flwr.common import EvaluateRes, FitRes, Scalar
+from flwr.common import EvaluateIns, EvaluateRes, FitRes, Parameters, Scalar, parameters_to_ndarrays
 
 from typing import Dict, List, Tuple, Optional, Union
-if __name__ == "__main__":
-    class AggregateCustomMetricStrategy(fl.server.strategy.FedAvg):
-        def aggregate_evaluate(
-            self,
-            server_round: int,
-            results: List[Tuple[ClientProxy, EvaluateRes]],
-            failures: List[Union[Tuple[ClientProxy, FitRes], BaseException]],
-        ) -> Tuple[Optional[float], Dict[str, Scalar]]:
-            """Aggregate evaluation accuracy using weighted average."""
 
-            if not results:
-                return None, {}
+class AggregateCustomMetricStrategy(fl.server.strategy.FedAvg):
 
-            # Call aggregate_evaluate from base class (FedAvg) to aggregate loss and metrics
-            aggregated_loss, aggregated_metrics = super().aggregate_evaluate(server_round, results, failures)
+    def __init__(self, save_global_path: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-            # Weigh accuracy of each client by number of examples used
-            accuracies = [r.metrics["Dice"] * r.num_examples for _, r in results]
-            examples = [r.num_examples for _, r in results]
+        self.best_dice_so_far = - float("inf")
+        self.save_global_path = Path(save_global_path)
 
-            # Aggregate and print custom metric
-            aggregated_accuracy = sum(accuracies) / sum(examples)
-            print(f"Round {server_round} accuracy aggregated from client results: {aggregated_accuracy}")
+        # Create path if it doesn't exist
+        self.save_global_path.mkdir(exist_ok=True, parents=True)
 
-            # Return aggregated loss and metrics (i.e., aggregated accuracy)
-            return aggregated_loss, {"Dice": aggregated_accuracy}
+    def save_model(self, server_round: int, avg_dice: float):
+        """Save global parameters to disk as list of NumPy arrays."""
+
+        ndarrays = parameters_to_ndarrays(self.global_model)
+        filename = self.save_global_path/f"global_model_round_{server_round}.pkl"
+
+        # construct artifact to save
+        to_save = {'ndarrays': ndarrays, 'avg_dice': avg_dice}
+
+        with open(filename, 'wb') as h:
+            pickle.dump(to_save, h, protocol=pickle.HIGHEST_PROTOCOL)
+
+    def configure_evaluate(self, server_round: int, parameters: Parameters, client_manager: ClientManager):
+        # Configure as usual
+        proxies_and_instructions = super().configure_evaluate(server_round, parameters, client_manager)
+
+        # Now keep a local copy of the parameters sent to the clients
+        # This is what we'll save to disk if a new best average dice metric is achieved.
+        self.global_model = parameters
+
+        return proxies_and_instructions
+
+    def aggregate_evaluate(
+        self,
+        server_round: int,
+        results: List[Tuple[ClientProxy, EvaluateRes]],
+        failures: List[Union[Tuple[ClientProxy, FitRes], BaseException]],
+    ) -> Tuple[Optional[float], Dict[str, Scalar]]:
+        """Aggregate evaluation accuracy using weighted average."""
+
+        if not results:
+            return None, {}
+
+        # Call aggregate_evaluate from base class (FedAvg) to aggregate loss and metrics
+        aggregated_loss, aggregated_metrics = super().aggregate_evaluate(server_round, results, failures)
+
+        # Weigh accuracy of each client by number of examples used
+        accuracies = [r.metrics["Dice"] * r.num_examples for _, r in results]
+        examples = [r.num_examples for _, r in results]
+
+        # Aggregate and print custom metric
+        aggregated_accuracy = sum(accuracies) / sum(examples)
+        print(f"Round {server_round} accuracy aggregated from client results: {aggregated_accuracy}")
+
+        if aggregated_accuracy > self.best_dice_so_far:
+            print(f"New best average dice achieved (round {server_round})")
+            self.save_model(server_round, aggregated_accuracy)
+            self.best_dice_so_far = aggregated_accuracy
+
+        # Return aggregated loss and metrics (i.e., aggregated accuracy)
+        return aggregated_loss, {"Dice": aggregated_accuracy}
+    
+
+def main():
 
     # Create strategy and run server
-    strategy = AggregateCustomMetricStrategy(
+    strategy = AggregateCustomMetricStrategy(save_global_path='global_models'
         # (same arguments as FedAvg here)
 )
     fl.server.start_server(
@@ -41,3 +86,7 @@ if __name__ == "__main__":
         config=fl.server.ServerConfig(num_rounds=500),
         strategy=strategy,
     )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi @adwaykanhere, this PR make the following changes:

* In all files, a command line argument asks for the path to the dataset (instead of having them hardcoded). You can see in the `README.md` how this works. 
* The strategy now saves the _global model_ once a new average _dice_ metric is obtained. 
* The strategy now gets passed a callback to execute in its `evaluate()` method. You can add the code there to evaluate your global model on a dataset held by the server. I level some dummy code in there, currently it does nothing (only print a warning and sleep for 10s)
* I added some extra instructions on how to construct the python environment and how to download the dataset.

Issues/questions:
* I wasn't able to run the Pancreas client. Maybe I didn't quite understand how the dataset needs to be processed to go from 2 to 1 label.
* I understand that `mds.py` is the "centralized" version of the otherwise federated code in this repo. You'll see I updated that file too. I had to specify the `a_min` and `a_max` to the `load_data()` function. I copied them from the client scripts. Looks good?


Let me know what you think!