### PR TITLE
Add save option to clients when new best model is found and before ending FL

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,16 @@ python3 server.py
 ```
 
 ```bash
-# Start the Flower Liver client using 
-python3 client_spleen.py  --spleen-path=dataset/Task09_Spleen # or update the path if you didn't follow steps above
+# Start the Flower Liver client using
+# Specify where dataset is located and where to save local models
+python3 client_spleen.py  --spleen-path=dataset/Task09_Spleen --save-path output-spleen
 ```
 
 ```bash
-# Start the Flower Pancreas client using 
-python3 client_pan.py --pancreas-path=dataset/Task07_Pancreas # or update the path if you didn't follow steps above
+# Start the Flower Pancreas client using
+# Specify where dataset is located and where to save local models
+python3 client_pan.py --pancreas-path=dataset/Task07_Pancreas --save-path output-pancreas
 ```
 
+When client save a model, they will follwow the directory structure: `save-path/date/time/<model>`
 

--- a/client_spleen.py
+++ b/client_spleen.py
@@ -1,50 +1,14 @@
 import argparse
-from monai.utils import first, set_determinism
-from monai.transforms import (
-    AsDiscrete,
-    AsDiscreted,
-    EnsureChannelFirstd,
-    Compose,
-    CropForegroundd,
-    LoadImaged,
-    Orientationd,
-    RandCropByPosNegLabeld,
-    SaveImaged,
-    RandAffined,
-    ScaleIntensityRanged,
-    Spacingd,
-    Invertd,
-    Resized,
-)
-from monai.handlers.utils import from_engine
-from monai.networks.nets import UNet, BasicUNet
+from pathlib import Path
+from datetime import datetime
+from monai.utils import first
+from monai.networks.nets import UNet
 from monai.networks.layers import Norm
-from torch.optim.lr_scheduler import CosineAnnealingLR
-
-from monai.metrics import DiceMetric, ROCAUCMetric, MSEMetric
-from monai.networks.utils import copy_model_state
-from monai.optimizers import generate_param_groups
-from monai.losses import DiceLoss
-from monai.inferers import sliding_window_inference
-from monai.data import CacheDataset, DataLoader, Dataset, decollate_batch
-from monai.config import print_config
-from monai.apps import download_and_extract
 import torch
-import matplotlib.pyplot as plt
-import tempfile
-import shutil
-import os
-import glob
 import numpy as np
-import wandb
-import copy
-import nibabel as nib
 
 import msd
 
-import os
-import sys
-import timeit
 from collections import OrderedDict
 from typing import Dict, List, Tuple
 
@@ -63,6 +27,12 @@ parser.add_argument(
     required=True,
     type=str,
     help="Path to the Spleen dataset (e.g. datasets/Task09_Spleen). Download from medicaldecathlon.com.",
+)
+parser.add_argument(
+    "--save-path",
+    required=True,
+    type=str,
+    help="Path where this client will save local models (if doesn't exist, directory will be created)",
 )
 
 # pylint: enable=no-member
@@ -105,11 +75,17 @@ class MSDClient(fl.client.NumPyClient):
         trainloader: torch.utils.data.DataLoader,
         testloader: torch.utils.data.DataLoader,
         num_examples: Dict,
+        save_path: str,
     ) -> None:
         self.model = model
         self.trainloader = trainloader
         self.testloader = testloader
         self.num_examples = num_examples
+
+        # prepare directory where models will be saved
+        self.path = Path(save_path)/datetime.now().strftime('%d-%m-%Y/%H-%M-%S')
+        self.path.mkdir(parents=True, exist_ok=True)
+        print(f"Client will save to: {str(self.path)}")
 
     def get_parameters(self, config: Dict[str, str]) -> List[np.ndarray]:
         self.model.train()
@@ -136,6 +112,11 @@ class MSDClient(fl.client.NumPyClient):
     def fit(
         self, parameters: List[np.ndarray], config: Dict[str, str]
     ) -> Tuple[List[np.ndarray], int, Dict]:
+        if config['save_model']:
+            print("SAVE MODEL!! -- must implement")
+
+            #TODO: save model into self.path
+
         # Set model parameters, train model, return updated model parameters
         self.set_parameters(parameters)
         msd.train(self.model, self.trainloader, max_epochs=2, device=DEVICE)
@@ -169,7 +150,8 @@ def main() -> None:
 
 
     # Start client
-    client = MSDClient(model, trainloader, testloader, num_examples)
+    client = MSDClient(model, trainloader, testloader,
+                       num_examples, save_path=args.save_path).to_client()
     fl.client.start_numpy_client(server_address="127.0.0.1:8080", client=client)
 
 


### PR DESCRIPTION
Hi @adwaykanhere,

This PR introduces the following changes:
- To the clients: in `fit()` a client checks if `save_model` is set to `True`. If so, the model can be saved. (note this isn't implemented in the code, I leave you to do this in the way you think is more convenient). The clients need a new input argument when launching them `--save-path` to indicate where all models will be stored (internally the client constructor will append the data & time, so this ensures no overwriting of models can happen)
- To the strategy: it now edits in-place the instructions that are going to be sent to the client's when doing `fit()`. This is done in the `configure_fit()` method. What I do is to set the entry `save_model` and is set to True only if: (1) a new best _dice_ metric is found; (2) it's the final round.


Let me know what you think!