### PR TITLE
Upgrade to `flwr` 1.9 and remove `evaluate_fn` call

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,17 +92,17 @@ Next, you'll need your `SuperNode` (i.e. nodes containing the data that will eve
 
 ```bash
 # launches supernode wich will execute the the `ClientApp` in `client_spleen.py`
-flower-client-app client_spleen:app --insecure --server=<SUPERLINK_SERVER_IP>
+flower-client-app client_spleen:app --insecure --superlink=<SUPERLINK_SERVER_IP>
 
 # launch supernode pointing to a `ClientApp` making use of the pancreas data
-flower-client-app client_pan:app --insecure --server=<SUPERLINK_SERVER_IP>
+flower-client-app client_pan:app --insecure --superlink=<SUPERLINK_SERVER_IP>
 ```
 When client save a model, they will follwow the directory structure: `save-path/date/time/<model>`
 
 With the above done, you'll see nothing seems to happen. The `SuperNodes` periodically ping the `SuperLink` for messages that the `ServerApp` (which we haven't launched yet) is sending them. Without further due, let's launch the `ServerApp` to start the federation:
 
 ```bash
-flower-server-app server:app --insecure --server=<SUPERLINK_SERVER_IP>
+flower-server-app server:app --insecure --superlink=<SUPERLINK_SERVER_IP>
 ```
 
 You'll notice once the N rounds finish, the `SuperLink` and `SuperNode` remain idle. You can launch another `ServerApp` to start a new experiment (yes, without having to restart the `SuperNode` or `SuperLink`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flwr==1.8.0
+flwr==1.9.0
 monai==1.3.0
 matplotlib==3.8.3
 nibabel==5.2.1

--- a/server.py
+++ b/server.py
@@ -143,7 +143,8 @@ strategy = AggregateCustomMetricStrategy(
     total_rounds=rounds,
     save_global_path='global_models',
     on_fit_config_fn=get_on_fit_config_fn(),
-    evaluate_fn=get_evaluate_fn(server_dataset)) # pass your dataset here
+    # evaluate_fn=get_evaluate_fn(server_dataset) # pass your dataset here
+    )
 
 # Flower ServerApp
 # Launch via `flower-server-app server:app`


### PR DESCRIPTION
Hey @adwaykanhere this PR does three things:
- updates the `requirements.txt` to the latest version of Flower (1.9)
- Uses `--superlink` (instead of `--server` which is deprecated) to pass the address of the `SuperLink`
- Disables the centralised evaluation stage (since it's not implemented in the code).